### PR TITLE
Fix lint issues and cleanup utilities

### DIFF
--- a/src/check_env.py
+++ b/src/check_env.py
@@ -1,4 +1,6 @@
-import cv2, torch, ultralytics
+import cv2
+import torch
+import ultralytics
 print("OpenCV :", cv2.__version__)
 print("PyTorch:", torch.__version__, "GPU =", torch.cuda.is_available())
 print("YOLOv8 :", ultralytics.__version__)

--- a/src/clean_same_frames.py
+++ b/src/clean_same_frames.py
@@ -39,8 +39,6 @@ Options
 from __future__ import annotations
 import argparse
 import concurrent.futures as cf
-import hashlib
-import os
 import time
 from pathlib import Path
 

--- a/src/crop_minimap.py
+++ b/src/crop_minimap.py
@@ -65,7 +65,11 @@ cv2.convexHull と cv2.UMat に関するドキュメント
 """
 
 
-import cv2, yaml, sys, pathlib, tqdm,numpy as np
+import cv2
+import yaml
+import pathlib
+import tqdm
+import numpy as np
 
 
 cfg = yaml.safe_load(open("config.yaml", encoding="utf-8"))
@@ -79,8 +83,9 @@ M = cv2.getPerspectiveTransform(src_pts, dst_pts)
 
 
 # --- 入出力ディレクトリの準備 ---
-in_dir  = pathlib.Path("data/frames")
-out_dir = pathlib.Path("data/minimaps"); out_dir.mkdir(exist_ok=True)
+in_dir = pathlib.Path("data/frames")
+out_dir = pathlib.Path("data/minimaps")
+out_dir.mkdir(exist_ok=True)
 
 # --- 画像処理ループ ---
 # 入力ディレクトリのjpgファイルを名前順に処理

--- a/src/segment_rounds.py
+++ b/src/segment_rounds.py
@@ -23,7 +23,11 @@ Options (抜粋)
 """
 
 import numpy as np
-import argparse, cv2, os, shutil, time
+import argparse
+import cv2
+import os
+import shutil
+import time
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from threading import Lock, Thread


### PR DESCRIPTION
## Summary
- split imports and drop unused ones
- ensure minimap output directory creation is on its own line
- address lint warnings in all scripts

## Testing
- `ruff check src`
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684078e21ff48328b8dfd0205e7ca265