### PR TITLE
Add upload date subdir for frame extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,13 @@ git version is 2.43.0.windows.1
 
 ## 動画URLからフレーム抽出  
 
-MapSight_AI/data　でコマンド実行．  
-コマンド:  
-YOUTUBE="<https://www.youtube.com/watch?v=tkbV9EJPak4>"  
-ffmpeg -i "$(yt-dlp -f best -g "$YOUTUBE")" \
-       -vf "fps=2,scale=1920:-2" -q:v 2 frames/frame_%05d.jpg  
+MapSight_AI/data でコマンド実行．
+コマンド例:
+./extract_frames.sh "https://www.youtube.com/watch?v=tkbV9EJPak4"
 
 ・fps=2 → 0.5 s ごとに 1 枚（後で変更可能） # 0.5に変更済み
-・生成先 frames/ は後段スクリプトが再帰検索します。  
-・画質を保ちたい場合は -q:v 2（2-31、数字が小さいほど高画質）。  
+・生成先 data/frames/<公開日>/ は後段スクリプトが再帰検索します。
+・画質を保ちたい場合は -q:v 2（2-31、数字が小さいほど高画質）。
 
 ## githubの開発フロー早わかり・説明
 

--- a/extract_frames.sh
+++ b/extract_frames.sh
@@ -4,7 +4,8 @@
 # -----------------------------------------------------------------------------
 # 既存ディレクトリをそのまま活用します。
 #   * data/raw_videos/   … 元動画を保存（存在しなければ自動作成）
-#   * data/frames/            … 抽出 JPG を保存（存在しなければ自動作成）
+#   * data/frames/<upload-date>/
+#                        … 抽出 JPG を保存（存在しなければ自動作成）
 #
 # Usage:
 #   ./extract_frames.sh <VIDEO_URL> [FPS] [WIDTH]
@@ -29,6 +30,16 @@ WIDTH="${3:-1920}"
 
 RAW_DIR="data/raw_videos"
 FRAMES_DIR="data/frames"
+
+# YouTube の場合は公開日サブディレクトリを作成 -----------------------------
+if [[ "$VIDEO_URL" =~ (youtu\.be|youtube\.com) ]]; then
+  UPLOAD_DATE="$(yt-dlp --print "%(upload_date)s" "$VIDEO_URL" | head -n 1)"
+  if [[ "$UPLOAD_DATE" =~ ^[0-9]{8}$ ]]; then
+    UPLOAD_DATE="${UPLOAD_DATE:0:4}-${UPLOAD_DATE:4:2}-${UPLOAD_DATE:6:2}"
+    FRAMES_DIR="${FRAMES_DIR}/${UPLOAD_DATE}"
+  fi
+fi
+
 mkdir -p "$RAW_DIR" "$FRAMES_DIR"
 
 # --- 1) 動画ダウンロード: URL 種別で分岐 ------------------------------------


### PR DESCRIPTION
## Summary
- save frames under `data/frames/<upload-date>` when source is YouTube
- document new extraction command in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426e62d1c0832887a577bfd8ab29d1