### PR TITLE
Fix Pylance median error

### DIFF
--- a/src/clean_same_frames.py
+++ b/src/clean_same_frames.py
@@ -62,8 +62,8 @@ def phash64(img: np.ndarray, hash_size: int = 8) -> int:
     dct = cv2.dct(img_resized)
     # 4. take top‑left (hash_size×hash_size) coefficients, excluding DC term
     dct_low = dct[:hash_size, :hash_size]
-    dct_flat = dct_low.flatten()[1:]  # skip DC
-    med = np.median(dct_flat)
+    dct_flat = np.asarray(dct_low.flatten()[1:], dtype=np.float32)  # skip DC
+    med = float(np.median(dct_flat))
     # 5. build hash: 1 if coef > median
     bits = (dct_flat > med).astype(np.uint8)
     # pad to 64 bits


### PR DESCRIPTION
## Summary
- ensure float dtype for DCT coefficients before computing median in `phash64`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427ebaddcc8328b06b53efaf9ec47a